### PR TITLE
Fix AC->TC page fault forwarding

### DIFF
--- a/sys/src/9/pc64/acore.c
+++ b/sys/src/9/pc64/acore.c
@@ -115,16 +115,16 @@ acsched(void)
 	acmmuswitch();
 	for(;;){
 		if (0)acstackok();
-		iprint("acstackok is ok\n");
-		iprint("&m->icc->fn %p fn %p\n", &m->icc->fn, m->icc->fn);
+		DBG("acstackok is ok\n");
+		DBG("&m->icc->fn %p fn %p\n", &m->icc->fn, m->icc->fn);
 		while(m->icc->fn == nil)
 			mwait(&m->icc->fn);
-		iprint("m %p m->icc->flushtlb %d m->icc->fn %p\n", m, m->icc->flushtlb, m->icc->fn);
+		DBG("m %p m->icc->flushtlb %d m->icc->fn %p\n", m, m->icc->flushtlb, m->icc->fn);
 		if(m->icc->flushtlb)
 			acmmuswitch();
-		iprint("acsched: cpu%d: fn %#p\n", m->machno, m->icc->fn);
+		DBG("acsched: cpu%d: fn %#p\n", m->machno, m->icc->fn);
 		m->icc->fn();
-		iprint("acsched: cpu%d: idle\n", m->machno);
+		DBG("acsched: cpu%d: idle\n", m->machno);
 		mfence();
 		m->icc->fn = nil;
 	}
@@ -143,38 +143,40 @@ actouser(void)
 
 	fpinit();
 	u = m->proc->dbgreg;
-	iprint("  AX %.16lluX  BX %.16lluX  CX %.16lluX\n",
-		u->ax, u->bx, u->cx);
-	iprint("  DX %.16lluX  SI %.16lluX  DI %.16lluX\n",
-		u->dx, u->si, u->di);
-	iprint("  BP %.16lluX  R8 %.16lluX  R9 %.16lluX\n",
-		u->bp, u->r8, u->r9);
-	iprint(" R10 %.16lluX R11 %.16lluX R12 %.16lluX\n",
-		u->r10, u->r11, u->r12);
-	iprint(" R13 %.16lluX R14 %.16lluX R15 %.16lluX\n",
-		u->r13, u->r14, u->r15);
-	iprint("  CS %.4lluX   SS %.4lluX    PC %.16lluX  SP %.16lluX\n",
-		u->cs & 0xffff, u->ss & 0xffff, u->pc, u->sp);
-	iprint("TYPE %.2lluX  ERROR %.4lluX FLAGS %.8lluX\n",
-		u->type & 0xff, u->error & 0xffff, u->flags & 0xffffffff);
-
-	/*
-	 * Processor control registers.
-	 * If machine check exception, time stamp counter, page size extensions
-	 * or enhanced virtual 8086 mode extensions are supported, there is a
-	 * CR4. If there is a CR4 and machine check extensions, read the machine
-	 * check address and machine check type registers if RDMSR supported.
-	 */
-	iprint(" CR0 %8.8llux CR2 %16.16llux CR3 %16.16llux",
-		getcr0(), getcr2(), getcr3());
-	if(m->cpuiddx & (Mce|Tsc|Pse|Vmex)){
-		iprint(" CR4 %16.16llux\n", getcr4());
-		if(u->type == 18)
-			dumpmcregs();
+	if (0) { /* TODO(PAL): cleanup */
+		iprint("  AX %.16lluX  BX %.16lluX  CX %.16lluX\n",
+			u->ax, u->bx, u->cx);
+		iprint("  DX %.16lluX  SI %.16lluX  DI %.16lluX\n",
+			u->dx, u->si, u->di);
+		iprint("  BP %.16lluX  R8 %.16lluX  R9 %.16lluX\n",
+			u->bp, u->r8, u->r9);
+		iprint(" R10 %.16lluX R11 %.16lluX R12 %.16lluX\n",
+			u->r10, u->r11, u->r12);
+		iprint(" R13 %.16lluX R14 %.16lluX R15 %.16lluX\n",
+			u->r13, u->r14, u->r15);
+		iprint("  CS %.4lluX   SS %.4lluX    PC %.16lluX  SP %.16lluX\n",
+			u->cs & 0xffff, u->ss & 0xffff, u->pc, u->sp);
+		iprint("TYPE %.2lluX  ERROR %.4lluX FLAGS %.8lluX\n",
+			u->type & 0xff, u->error & 0xffff, u->flags & 0xffffffff);
+	
+		/*
+		 * Processor control registers.
+		 * If machine check exception, time stamp counter, page size extensions
+		 * or enhanced virtual 8086 mode extensions are supported, there is a
+		 * CR4. If there is a CR4 and machine check extensions, read the machine
+		 * check address and machine check type registers if RDMSR supported.
+		 */
+		iprint(" CR0 %8.8llux CR2 %16.16llux CR3 %16.16llux",
+			getcr0(), getcr2(), getcr3());
+		if(m->cpuiddx & (Mce|Tsc|Pse|Vmex)){
+			iprint(" CR4 %16.16llux\n", getcr4());
+			if(u->type == 18)
+				dumpmcregs();
+		}
+		iprint("  ur %#p up %#p\n", u, up);
+		iprint("cpu%d: touser m %p m->proc %p m->stack %p\n", m->machno, m, m->proc, m->stack);
+		iprint("cpu%d: touser usp = %#p entry %#p\n", m->machno, u->sp, u->pc);
 	}
-	iprint("  ur %#p up %#p\n", u, up);
-	iprint("cpu%d: touser m %p m->proc %p m->stack %p\n", m->machno, m, m->proc, m->stack);
-	iprint("cpu%d: touser usp = %#p entry %#p\n", m->machno, u->sp, u->pc);
 	//while(1);
 	xactouser(u->sp);
 	panic("actouser RETURNED, can't happen");
@@ -211,14 +213,11 @@ actrap(Ureg *u)
 	}
 	/* there are a few traps we handle quickly, in particular
 	 * API timer interrupts and such. */
-	print("ACTRAP: %lld of %d\n", u->type, nelem(acvctl));
 	if(u->type < nelem(acvctl)){
 		v = acvctl[u->type];
 		if(v != nil){
 			DBG("actrap: cpu%d: %ulld, vector = %p\n", m->machno, u->type, v);
-			/*n =*/ v->f(u, v->a);
-		/*	if(n != nil)
-				goto Post; */
+			v->f(u, v->a);
 			return;
 		}
 	}
@@ -310,36 +309,38 @@ acsysret(void)
 {
 	Ureg *u = m->proc->dbgreg;
 	fpukexit(u, m->proc->fpsave);
-	iprint("  AX %.16lluX  BX %.16lluX  CX %.16lluX\n",
-		u->ax, u->bx, u->cx);
-	iprint("  DX %.16lluX  SI %.16lluX  DI %.16lluX\n",
-		u->dx, u->si, u->di);
-	iprint("  BP %.16lluX  R8 %.16lluX  R9 %.16lluX\n",
-		u->bp, u->r8, u->r9);
-	iprint(" R10 %.16lluX R11 %.16lluX R12 %.16lluX\n",
-		u->r10, u->r11, u->r12);
-	iprint(" R13 %.16lluX R14 %.16lluX R15 %.16lluX\n",
-		u->r13, u->r14, u->r15);
-	iprint("  CS %.4lluX   SS %.4lluX    PC %.16lluX  SP %.16lluX\n",
-		u->cs & 0xffff, u->ss & 0xffff, u->pc, u->sp);
-	iprint("TYPE %.2lluX  ERROR %.4lluX FLAGS %.8lluX\n",
-		u->type & 0xff, u->error & 0xffff, u->flags & 0xffffffff);
+	if (0){ /* TODO(PAL): Remove */
+		iprint("  AX %.16lluX  BX %.16lluX  CX %.16lluX\n",
+			u->ax, u->bx, u->cx);
+		iprint("  DX %.16lluX  SI %.16lluX  DI %.16lluX\n",
+			u->dx, u->si, u->di);
+		iprint("  BP %.16lluX  R8 %.16lluX  R9 %.16lluX\n",
+			u->bp, u->r8, u->r9);
+		iprint(" R10 %.16lluX R11 %.16lluX R12 %.16lluX\n",
+			u->r10, u->r11, u->r12);
+		iprint(" R13 %.16lluX R14 %.16lluX R15 %.16lluX\n",
+			u->r13, u->r14, u->r15);
+		iprint("  CS %.4lluX   SS %.4lluX    PC %.16lluX  SP %.16lluX\n",
+			u->cs & 0xffff, u->ss & 0xffff, u->pc, u->sp);
+		iprint("TYPE %.2lluX  ERROR %.4lluX FLAGS %.8lluX\n",
+			u->type & 0xff, u->error & 0xffff, u->flags & 0xffffffff);
 
-	/*
-	 * Processor control registers.
-	 * If machine check exception, time stamp counter, page size extensions
-	 * or enhanced virtual 8086 mode extensions are supported, there is a
-	 * CR4. If there is a CR4 and machine check extensions, read the machine
-	 * check address and machine check type registers if RDMSR supported.
-	 */
-	iprint(" CR0 %8.8llux CR2 %16.16llux CR3 %16.16llux",
-		getcr0(), getcr2(), getcr3());
-	if(m->cpuiddx & (Mce|Tsc|Pse|Vmex)){
-		iprint(" CR4 %16.16llux\n", getcr4());
-		if(u->type == 18)
-			dumpmcregs();
+		/*
+		 * Processor control registers.
+		 * If machine check exception, time stamp counter, page size extensions
+		 * or enhanced virtual 8086 mode extensions are supported, there is a
+		 * CR4. If there is a CR4 and machine check extensions, read the machine
+		 * check address and machine check type registers if RDMSR supported.
+		 */
+		iprint(" CR0 %8.8llux CR2 %16.16llux CR3 %16.16llux",
+			getcr0(), getcr2(), getcr3());
+		if(m->cpuiddx & (Mce|Tsc|Pse|Vmex)){
+			iprint(" CR4 %16.16llux\n", getcr4());
+			if(u->type == 18)
+				dumpmcregs();
+		}
+		iprint("  ur %#p up %#p\n", u, up);
 	}
-	iprint("  ur %#p up %#p\n", u, up);
 	DBG("acsysret m %p m->machno %d m->proc %p u->sp %p sp %p\n", m, m->machno, m->proc, u->sp, sp);
 	if (sp != u->sp)
 		print("THIS CAN NOT HAPPEN: SP %p != u->sp %p", sp, u->sp);

--- a/sys/src/9/pc64/tcore.c
+++ b/sys/src/9/pc64/tcore.c
@@ -8,7 +8,7 @@
 #include	"../port/pci.h"
 #include	"ureg.h"
 
-#define DBG if(1)print
+#define DBG if(0)print
 
 Lock nixaclock;	/* NIX AC lock; held while assigning procs to cores */
 
@@ -153,7 +153,7 @@ runac(Mach *mp, APfunc func, int flushtlb, void *a, long n)
 		 *	memmove(dgp, spg, m->pml4->daddr * sizeof(PTE));
 		 */
 		memmove(dpg, spg, PTSZ);
-		if(1){
+		if(0){
 			print("runac: upac pml4 %#p\n", up->ac->pml4);
 			dumpptepg(4, PADDR(up->ac->pml4));
 		}
@@ -181,10 +181,10 @@ runac(Mach *mp, APfunc func, int flushtlb, void *a, long n)
 	qunlock(&up->debug);
 	poperror();
 	mfence();
-	print("cpu%d waits in sched mach is %p\n", m->machno, m);
+	DBG("cpu%d waits in sched mach is %p\n", m->machno, m);
 	mp->icc->fn = func;
 	sched();
-	print("cpu%d returns from waiting for AC, m is %p\n", m->machno, m);
+	DBG("cpu%d returns from waiting for AC, m is %p\n", m->machno, m);
 	return mp->icc->rc;
 }
 
@@ -250,6 +250,62 @@ dumpptepg(int lvl, u64int pa)
 				dumpptepg(lvl-1, PPN(pte[i]));
 		}
 }
+
+static void
+tcfaultnote(Mach *m, Ureg *ureg, char *access, uintptr addr)
+{
+	extern void checkpages(void);
+	char buf[ERRMAX];
+
+	if(!userureg(ureg)){
+		dumpregs(ureg);
+		panic("cpu%d:fault: %s addr=%#p", m->machno, access, addr);
+	}
+	checkpages();
+	snprint(buf, sizeof(buf), "sys: trap: fault %s addr=%#p", access, addr);
+	postnote(up, 1, buf, NDebug);
+}
+
+static void
+tcfaultamd64(Mach *m, Ureg* ureg, void*)
+{
+	uintptr addr;
+	int read, user;
+
+	addr = getcr2(); //m->cr2;
+	read = !(ureg->error & 2);
+	user = userureg(ureg);
+	if(user)
+		up->insyscall = 1;
+	else {
+		extern void _peekinst(void);
+
+		if((void(*)(void))ureg->pc == _peekinst){
+			ureg->pc += 2;
+			return;
+		}
+		if(addr >= USTKTOP)
+			panic("kernel fault: bad address pc=%#p addr=%#p", ureg->pc, addr);
+		if(up == nil)
+			panic("kernel fault: no user process pc=%#p addr=%#p", ureg->pc, addr);
+		if(waserror()){
+			if(up->nerrlab == 0){
+				pprint("suicide: sys: %s\n", up->errstr);
+				pexit(up->errstr, 1);
+			}
+			nexterror();
+		}
+	}
+
+	if(fault(addr, ureg->pc, read))
+		tcfaultnote(m, ureg, read? "read": "write", addr);
+
+	if(user)
+		up->insyscall = 0;
+	else
+		poperror();
+}
+
 
 /*
  * Move the current process to an application core.
@@ -323,15 +379,21 @@ runacore(void)
 				ureg->type = VectorIPI;		/* NOP */
 				break;
 			default:
+				if(!userureg(ureg))
+					DBG("runacore: Not a user space process?\n\n\n\n");
 				putcr3(PADDR(m->pml4));
-				if(0 && ureg->type == VectorPF){
-					print("before PF:\n");
-					print("AC:\n");
-					dumpptepg(4, PADDR(up->ac->pml4));
-					print("\n%s:\n", rolename[NIXTC]);
-					dumpptepg(4, PADDR(m->pml4));
+				putcr2(up->ac->cr2);
+				if(ureg->type == VectorPF){
+					if (0){
+						dumpptepg(4, PADDR(up->ac->pml4));
+						print("\n%s:\n", rolename[NIXTC]);
+						dumpptepg(4, PADDR(m->pml4));
+						dumpregs(ureg);
+					}
+					tcfaultamd64(m, ureg, nil);
+				} else {
+					trap(ureg);
 				}
-				trap(ureg);
 			}
 			splx(s);
 			flush = 1;
@@ -340,12 +402,12 @@ runacore(void)
 		case ICCSYSCALL:
 			DBG("cpu%d:runacore: syscall bp %#ullx ureg %#p\n", m->machno, ureg->bp, ureg);
 			putcr3(PADDR(m->pml4));
-			if(1){
+			if(0){
 				up->s = *((Sargs*)((uintptr)ureg->sp+BY2WD));
 				syscallfmt(ureg->bp, ureg->pc, (va_list)up->s.args);
 				print("syscall: %s\n", up->syscalltrace);
 			}
-			up->printsyscall = 1;
+			// up->printsyscall = 1;
 			syscall(ureg);
 			flush = 1;
 			fn = acsysret;
@@ -356,8 +418,6 @@ runacore(void)
 				print("up->ac is now nil; going ToTC\n");
 				goto ToTC;
 			}
-			if(0)
-				nixprepage(-1);
 			break;
 		default:
 			panic("runacore: unexpected rc = %d", rc);

--- a/sys/src/9/pc64/trap.c
+++ b/sys/src/9/pc64/trap.c
@@ -416,7 +416,6 @@ faultamd64(Ureg* ureg, void*)
 {
 	uintptr addr;
 	int read, user;
-//	DBG("faultamd64: cpu%d: mach is %p\n", m->machno, m);
 
 	addr = getcr2();
 	read = !(ureg->error & 2);

--- a/sys/src/9/port/proc.c
+++ b/sys/src/9/port/proc.c
@@ -9,6 +9,8 @@
 #include	"tos.h"
 #include	"ureg.h"
 
+#define DBG if(1)iprint
+
 enum {
 	Scaling = 2,
 };

--- a/sys/src/9/port/segment.c
+++ b/sys/src/9/port/segment.c
@@ -956,7 +956,6 @@ segio(Segio *sio, Segment *s, void *a, long n, vlong off, int read)
 }
 
 // NIX
-#define DBG print
 static void
 prepageseg(int i)
 {
@@ -967,7 +966,6 @@ prepageseg(int i)
 	s = up->seg[i];
 	if(s == nil)
 		return;
-	DBG("prepage: base %#p top %#p\n", s->base, s->top);
 	pgsz = 4096; // XXX pull in nix pgsz stuff. m->pgsz[s->pgszi];
 	for(addr = s->base; addr < s->top; addr += pgsz){
 		qlock(s);

--- a/sys/src/9/port/sysnix.c
+++ b/sys/src/9/port/sysnix.c
@@ -9,6 +9,8 @@
 
 #include	<a.out.h>
 
+#define DBG if(0)print
+
 /* a note on ABI. For standard exec, the va_list is a standard sysexec: 
  * a char * and a char **, two pointers. 
  * For sysexecac, va_list contains a flags, and a va_list compatible
@@ -23,12 +25,10 @@ sysexecac(va_list list)
 	char ** args;
 
  	flags = va_arg(eac, uintptr);
-	print("sysexecac: flags %p\n", flags);
  	switch(flags){
  	case EXTC:
 		break;
  	default:
-		print("sysexecac: normal\n");
  		return sysexec(list);
  	case EXAC:
  		up->ac = getac(up, -1);
@@ -49,7 +49,7 @@ sysexecac(va_list list)
 		nexterror();
 	}
 	args = va_arg(eac, char **);
-	print("args is %p; args[0] is %p; args[1] is %p\n", args, ((uintptr*)args)[0], ((uintptr*)args)[1]);
+	DBG("args is %p; args[0] is %p; args[1] is %p\n", args, ((uintptr*)args)[0], ((uintptr*)args)[1]);
 	ar0 = sysexec((va_list)args);
 
 	up->procctl = Proc_toac;

--- a/sys/src/9/port/sysproc.c
+++ b/sys/src/9/port/sysproc.c
@@ -105,7 +105,6 @@ sysrfork(va_list list)
 			if(up->ac != nil)
 				up->procctl = Proc_totc;
 		} */
-DBG("return after non-proc rfork\n");
 		return 0;
 	}
 
@@ -120,6 +119,7 @@ DBG("return after non-proc rfork\n");
 		}else{
 			print("warning: rfork: no available ac for the child, it runs in the tc\n");
 			p->procctl = 0;
+			// TODO(PAL): I think we need this: nexterror(); 
 		}
 	}
 
@@ -328,7 +328,7 @@ sysexec(va_list list)
 	Tos *tos;
 	Chan *tc;
 	Fgrp *f;
-DBG("Exec on CPU%d\n", m->machno);
+
 	args = elem = nil;
 	file0 = va_arg(list, char*);
 	validaddr((uintptr)file0, 1, 0);


### PR DESCRIPTION
CR2 was not being forwarded from the AC.  We now set CR2 with the saved value. We also direct page fault handling to a tcfaultamd64 handler that can post correct note data in the case of errors, indicating which core actually faulted, instead of which core serviced the fault.
Also removes and/or disables significant noisy debug output.

The main point of possible contention is the duplication of the faultamd64 code.  I don't see a clean way to keep core reporting out the usual failure path.  But it is not strictly necessary.