### PR TITLE
Don't allow wiring processes to nix ACs

### DIFF
--- a/sys/src/9/pc64/tcore.c
+++ b/sys/src/9/pc64/tcore.c
@@ -19,6 +19,15 @@ Lock nixaclock;	/* NIX AC lock; held while assigning procs to cores */
 extern void actrapret(void);
 extern void acsysret(void);
 
+int
+isnixac(int core) {
+	Mach *mp;
+	mp = machp[core];
+	if(mp == nil || mp->online == 0 || mp->proc != nil)
+		return 0;
+	return mp->nixtype == NIXAC;
+}
+
 Mach*
 getac(Proc *p, int core)
 {

--- a/sys/src/9/port/proc.c
+++ b/sys/src/9/port/proc.c
@@ -741,6 +741,7 @@ newproc(void)
 	return p;
 }
 
+extern int isnixac(int core);
 /*
  * wire this proc to a machine
  */
@@ -762,14 +763,21 @@ procwired(Proc *p, int a)
 		}
 		a = 0;
 		for(i=0; i<conf.nmach; i++)
-			if(nwired[i] < nwired[a])
+			if(!isnixac(i) && (nwired[i] < nwired[a]))
 				a = i;
 	} else {
 		/* use the virtual machine requested */
 		a = a % conf.nmach;
+		if(isnixac(a)){
+			DBG("Failed to wire proc %ld to core %d\n", p->pid, a);
+			error("Can't wire process to a NIX AC");
+			return;
+		}
 	}
 	p->affinity = a;
 	p->wired = 1;
+
+	DBG("Wiring proc %ld to core %d\n", p->pid, a);
 }
 
 void


### PR DESCRIPTION
This should suffice.  The scheduler does't set affinity to anything except the core number the scheduler is executing on.  There is no scheduler on AC, so we don't have the possibility of affinity pointing to an AC.