### PR TITLE
riscv64: plic intrenable/irq after arm64 gic; pci fan-out via IRQpci1..4

### DIFF
--- a/sys/src/9/riscv64/io.h
+++ b/sys/src/9/riscv64/io.h
@@ -1,3 +1,10 @@
+enum {
+	IRQpci1		= 32,
+	IRQpci2		= 33,
+	IRQpci3		= 34,
+	IRQpci4		= 35,
+};
+
 #define BUSUNKNOWN (-1)
 #define PCIWINDOW	0
 #define	PCIWADDR(x)	(PADDR(x)+PCIWINDOW)

--- a/sys/src/9/riscv64/main.c
+++ b/sys/src/9/riscv64/main.c
@@ -287,11 +287,11 @@ main(void)
 	print("\nPlan %d\n", 9);
 	print("conf.mem[0].base %p, conf.mem[0].limit %p, conf.mem[0].npage %lud\n", conf.mem[0].base, conf.mem[0].limit, conf.mem[0].npage);
 #ifdef xxx
-	trapinit(); print("DONE 	trapinit();\n"); 
-	fpuinit(); print("DONE 	fpuinit();\n"); 
-	intrinit(); print("DONE 	intrinit();\n"); 
+	trapinit(); print("DONE 	trapinit();\n");
+	fpuinit(); print("DONE 	fpuinit();\n");
 #endif
-	clockinit(); print("DONE 	clockinit();\n"); 
+	intrinit(); print("DONE 	intrinit();\n");
+	clockinit(); print("DONE 	clockinit();\n");
 	timebase = 10*Mhz;
 	calibrate(); print("DONE calibrate\n");
 	clocksanity(); print("DONE clocksanity\n");

--- a/sys/src/9/riscv64/mkfile
+++ b/sys/src/9/riscv64/mkfile
@@ -49,6 +49,7 @@ OBJ=\
 	main.$O\
 	mmu.$O\
 	mem.$O\
+	plic.$O\
 	trap.$O\
 	clock.$O\
 	fp.$O\

--- a/sys/src/9/riscv64/pciqemu.c
+++ b/sys/src/9/riscv64/pciqemu.c
@@ -91,12 +91,10 @@ pciinterrupt(Ureg *ureg, void *)
 static void
 pciintrinit(void)
 {
-	/*
 	intrenable(IRQpci1, pciinterrupt, nil, BUSUNKNOWN, "pci");
 	intrenable(IRQpci2, pciinterrupt, nil, BUSUNKNOWN, "pci");
 	intrenable(IRQpci3, pciinterrupt, nil, BUSUNKNOWN, "pci");
 	intrenable(IRQpci4, pciinterrupt, nil, BUSUNKNOWN, "pci");
-	*/
 }
 
 void

--- a/sys/src/9/riscv64/plic.c
+++ b/sys/src/9/riscv64/plic.c
@@ -1,0 +1,114 @@
+#include "u.h"
+#include "../port/lib.h"
+#include "mem.h"
+#include "dat.h"
+#include "fns.h"
+#include "io.h"
+#include "../port/pci.h"
+#include "ureg.h"
+#include "sysreg.h"
+#include "riscv64.h"
+#include "../port/error.h"
+
+enum {
+	PLICBASE	= 0x0c000000,
+	PLICSIZE	= 0x04000000,
+
+	Suctxt		= 1,		/* S-mode context for hart 0 on qemu-virt */
+	Defprio		= 1,
+};
+
+extern uintptr setsie(uintptr);
+
+static Lock vctllock;
+static Vctl *vctl[Ngintr];
+static Plic *plic;
+
+void
+intrinit(void)
+{
+	uint i;
+
+	plic = (Plic*)vmap(PLICBASE, PLICSIZE);
+	if(plic == nil)
+		panic("intrinit: plic vmap");
+
+	/* mask every source */
+	for(i = Firstirq; i < Ngintr; i++){
+		plic->prio[i] = 0;
+		plic->enabits[Suctxt][i/32] &= ~(1u << (i & 31));
+	}
+	plic->context[Suctxt].priothresh = 0;
+	coherence();
+
+	/* enable S-mode external interrupts in SIE CSR */
+	setsie(Seie);
+}
+
+/*
+ *  called by trap.c to handle external interrupts from the plic.
+ *  returns 0; the plic never delivers clock interrupts.
+ */
+int
+irq(Ureg *ureg)
+{
+	Vctl *v;
+	uint id;
+
+	m->intr++;
+	while((id = plic->context[Suctxt].claimcompl) != 0){
+		if(id < Ngintr){
+			for(v = vctl[id]; v != nil; v = v->next)
+				v->f(ureg, v->a);
+		}
+		plic->context[Suctxt].claimcompl = id;
+		coherence();
+	}
+	return 0;
+}
+
+void
+intrenable(int irq, void (*f)(Ureg*, void*), void *a, int tbdf, char *name)
+{
+	Vctl *v;
+
+	if(BUSTYPE(tbdf) == BusPCI){
+		pciintrenable(tbdf, f, a);
+		return;
+	}
+
+	if(tbdf != BUSUNKNOWN)
+		return;
+	if((uint)irq < Firstirq || (uint)irq >= Ngintr)
+		return;
+
+	v = mallocz(sizeof(Vctl), 1);
+	if(v == nil)
+		panic("intrenable: no mem");
+	v->isintr = 1;
+	v->irq = irq;
+	v->vno = irq;
+	v->tbdf = tbdf;
+	v->f = f;
+	v->a = a;
+	v->cpu = -1;
+	strncpy(v->name, name, KNAMELEN-1);
+
+	lock(&vctllock);
+	v->next = vctl[irq];
+	vctl[irq] = v;
+
+	plic->prio[irq] = Defprio;
+	plic->enabits[Suctxt][irq/32] |= 1u << (irq & 31);
+	coherence();
+	unlock(&vctllock);
+}
+
+void
+intrdisable(int, void (*f)(Ureg*, void*), void *a, int tbdf, char*)
+{
+	if(BUSTYPE(tbdf) == BusPCI){
+		pciintrdisable(tbdf, f, a);
+		return;
+	}
+}

--- a/sys/src/9/riscv64/trap.c
+++ b/sys/src/9/riscv64/trap.c
@@ -783,64 +783,10 @@ if (0)sbiputc('-');
  * these are never clock interrupts, so returns 0 (not a clockintr).
  */
 int
-intr(Ureg* ureg, Cause *cp)
+intr(Ureg *ureg, Cause *cp)
 {
-	USED(ureg); USED(cp); 
-	panic("implement intr");
-#ifdef x
-	m->intr++;
-	int id, ctxt, vno, trips;
-	Vctl *vec;
-
-	if (++m->intrdepth > 1)
-		iprint("cpu%d: nested intrs at depth %d\n", m->machno,
-			m->intrdepth);
-	ctxt = m->plicctxt + Super;
-	if (Intrdebug && !soc.poll)
-		iprint("intr: checking plic for ctxt %d\n", ctxt);
-	trips = 100;
-	while (soc.plic && (id = plicclaim(ctxt)) != 0) {
-		m->perf.intrts = perfticks();
-		/* id is actual cause, global irq.  map to a vector. */
-		/* cp->vno = */ vno = vctlidx(id, Globalintr);
-		if (vno < 0)
-			panic("intr: intr id %d out of range", id);
-
-		if (Intrdebug)
-			iprint("intr: plic id %d vector %d\n", id, vno);
-		vec = vctl[vno];
-		if (vec == nil) {		/* maybe it's spurious? */
-			plicdisable(vno);
-			iprint("intr: no vector set up for intr id %d\n", id);
-		} else
-			callintrsvc(ureg, vec);
-		pliccompl(id, ctxt);
-		intrtime(m, vno);
-
-		if (--trips <= 0) {
-			plicoff();
-			soc.plic = 0;		/* poll in future */
-			iprint("intr: stuck in plicclaim loop, id %d, polling\n",
-				id);
-		}
-	}
-	if (!soc.plic)
-		poll(ureg, cp);			/* mainly for tinyemu */
-	/* having no work is not unusual */
-	if (Intrdebug && !soc.poll)
-		iprint("intr: done\n");
-	m->intrdepth--;
-
-	/* in case the cpus all raced into wfi, always wake */
-	if(up)
-		preempted();
-	/*
-	 * procs waiting for this interrupt could be on
-	 * any cpu, so wake any idling cpus.
-	 */
-	idlewake();
-#endif
-	return 0;
+	USED(cp);
+	return irq(ureg);
 }
 
 static Traphandler traphandlers[Nfaulttypes] = {
@@ -985,7 +931,3 @@ mach2context(Mach *)
 	return ctxtoff;
 }
 
-void intrenable(int, void (*)(Ureg *, void *), void *, int, char *)
-{
-	print("TODO:intrenable\n");
-}


### PR DESCRIPTION
Functions related to the platform-level interrupt controller are moved to plic.c (similar to arm64/gic.c) and interrupts are enabled. Docs: https://docs.riscv.org/reference/plic/_attachments/riscv-plic.pdf